### PR TITLE
Fix to support post a json request with non-object content

### DIFF
--- a/lib/oasis/validator.ex
+++ b/lib/oasis/validator.ex
@@ -61,6 +61,17 @@ defmodule Oasis.Validator do
     |> process_media_type(media_type, use_in, name, value)
   end
 
+  defp do_parse_and_validate!(%{schema: %{"type" => type}} = json_schema_root, "body", param_name, %{"_json" => value})
+    when type == "string" and is_bitstring(value)
+    when type == "number" and is_number(value)
+    when type == "integer" and is_integer(value)
+    when type == "array" and is_list(value)
+    when type == "boolean" and is_boolean(value) do
+    # Since `Plug.Parsers.JSON` parses a non-map body content into a "_json" key to allow proper param merging, here
+    # will unwrap the "_json" key and format the input body params as a matched type to the defined OpenAPI specification.
+    do_parse_and_validate!(json_schema_root, "body", param_name, value)
+  end
+
   defp do_parse_and_validate!(%{schema: schema} = json_schema_root, use_in, param_name, value) do
     try do
       Oasis.Parser.parse(schema, value)

--- a/test/support/gen/plug/pre_test_post_json.ex
+++ b/test/support/gen/plug/pre_test_post_json.ex
@@ -1,0 +1,73 @@
+defmodule Oasis.Gen.Plug.PreTestPostJSON do
+  use Oasis.Controller
+  use Plug.ErrorHandler
+
+  plug(
+    Plug.Parsers,
+    parsers: [:json],
+    json_decoder: Jason,
+    pass: ["*/*"]
+  )
+
+  plug(
+    Oasis.Plug.RequestValidator,
+    body_schema: %{
+      "required" => true,
+      "content" => %{
+        "application/json" => %{
+          "schema" => %ExJsonSchema.Schema.Root{
+            schema: %{
+              "items" => %{
+                "type" => "object",
+                "properties" => %{
+                  "id" => %{"type" => "integer"},
+                  "name" => %{"type" => "string"}
+                }
+              },
+              "type" => "array"
+            }
+          }
+        },
+        "application/vnd.api-v1+json" => %{
+          "schema" => %ExJsonSchema.Schema.Root{
+            schema: %{
+              "type" => "integer"
+            }
+          }
+        },
+        "application/vnd.api-v2+json" => %{
+          "schema" => %ExJsonSchema.Schema.Root{
+            schema: %{
+              "type" => "number"
+            }
+          }
+        },
+        "application/vnd.api-v3+json" => %{
+          "schema" => %ExJsonSchema.Schema.Root{
+            schema: %{
+              "properties" => %{
+                "_json" => %{
+                  "type" => "object",
+                  "properties" => %{
+                    "street_name" => %{"type" => "string"},
+                    "street_type" => %{"enum" => ["Street", "Avenue", "Boulevard"]},
+                    "id" => %{"type" => "integer"}
+                  }
+                }
+              },
+              "type" => "object"
+            }
+          }
+        },
+
+      }
+    }
+  )
+
+  def call(conn, opts) do
+    conn |> super(opts) |> Oasis.Gen.Plug.TestPost.call(opts) |> halt()
+  end
+
+  defdelegate handle_errors(conn, error), to: Oasis.Gen.Plug.TestPost
+
+end

--- a/test/support/http_server.ex
+++ b/test/support/http_server.ex
@@ -75,6 +75,10 @@ defmodule Oasis.HTTPServer.PlugRouter do
     to: Oasis.Gen.Plug.PreTestPostMultipart
   )
 
+  post("/test_post_json",
+    to: Oasis.Gen.Plug.PreTestPostJSON
+  )
+
   post("/test_post_non_validate",
     to: Oasis.Gen.Plug.TestPostNonValidate
   )


### PR DESCRIPTION
Related https://github.com/elixir-oasis/oasis/issues/19

By default there uses `Plug.Parsers.JSON` to parse JSON request body, but it will wrap a "_json" key into the request body parameter, this PR to properly unwrap this automatic appended "_json" key, and keep the request body parameter parsed and validated follow the schema of the defined OpenAPI specification.